### PR TITLE
Refactor tests to manually call oakumInit

### DIFF
--- a/source/include/oakum/oakum_api.h
+++ b/source/include/oakum/oakum_api.h
@@ -27,11 +27,11 @@ using OakumAllocationIdType = uint64_t;
 
 /// @brief Input configuration of the library via #oakumInit function
 struct OakumInitArgs {
-    bool trackStackTraces;              ///< Enable stack trace tracking. See #OakumStackFrame for more information.
-    bool threadSafe;                    ///< Enable thread safety inside the library.
-    bool sortAllocations;               ///< Sort allocations by their unique identifier in #oakumGetAllocations
-    const char *fallbackSymbolName;     ///< Symbol name to be used, when #oakumResolveStackTraceSymbols fails to resolve the actual name. May be null.
-    const char *fallbackSourceFileName; ///< Source file name to be used, when #oakumResolveStackTraceSourceLocations fails to resolve the actual name. May be null.
+    bool trackStackTraces = false;                ///< Enable stack trace tracking. See #OakumStackFrame for more information.
+    bool threadSafe = false;                      ///< Enable thread safety inside the library.
+    bool sortAllocations = false;                 ///< Sort allocations by their unique identifier in #oakumGetAllocations
+    const char *fallbackSymbolName = nullptr;     ///< Symbol name to be used, when #oakumResolveStackTraceSymbols fails to resolve the actual name. May be null.
+    const char *fallbackSourceFileName = nullptr; ///< Source file name to be used, when #oakumResolveStackTraceSourceLocations fails to resolve the actual name. May be null.
 };
 
 /// @brief Output configuration of the library reported by #oakumGetCapabilities function.

--- a/source/linux/stack_trace_linux.cpp
+++ b/source/linux/stack_trace_linux.cpp
@@ -43,6 +43,7 @@ static std::pair<std::string, size_t> addr2line(const char *binaryName, size_t v
 }
 
 bool StackTraceHelper::supportsSourceLocations() {
+    // TODO add flags from CMake
     std::string output = syscalls.runProcessForOutput("which", {"addr2line"});
     return !output.empty();
 }

--- a/source/oakum_controller.h
+++ b/source/oakum_controller.h
@@ -18,7 +18,7 @@ public:
     static bool isInitialized();
     static OakumController *getInstance();
 
-    const OakumCapabilities &getCapabilities() { return capabilities; }
+    const OakumCapabilities &getCapabilities() { return capabilities; } // TODO add unit tests for capabilities
 
     static void *allocateMemory(std::size_t size, bool noThrow);
     static void deallocateMemory(void *pointer);

--- a/tests/acceptance_tests/main.cpp
+++ b/tests/acceptance_tests/main.cpp
@@ -5,7 +5,7 @@
 
 #include <thread>
 
-using AcceptanceTest = OakumTestWithFallbackStrings;
+using AcceptanceTest = OakumTest;
 
 #if OAKUM_SOURCE_LOCATIONS_AVAILABLE == 1
 using AcceptanceTestWithSourceLocations = AcceptanceTest;
@@ -29,6 +29,8 @@ constexpr bool operatorInlined = false;
 #endif
 
 TEST_F(AcceptanceTest, givenMemoryLeakWhenDetectingLeaksThenReturnTrue) {
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
+
     EXPECT_EQ(OAKUM_SUCCESS, oakumDetectLeaks());
     auto memory = allocateMemoryFunction();
     EXPECT_EQ(OAKUM_LEAKS_DETECTED, oakumDetectLeaks());
@@ -37,6 +39,8 @@ TEST_F(AcceptanceTest, givenMemoryLeakWhenDetectingLeaksThenReturnTrue) {
 }
 
 TEST_F(AcceptanceTest, givenMemoryLeakWhenGettingAllocationThenReturnOneAllocationWithCorrectMetadata) {
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
+
     OakumAllocation *allocations{};
     size_t allocationsCount{};
     EXPECT_EQ(OAKUM_SUCCESS, oakumGetAllocations(&allocations, &allocationsCount));
@@ -60,6 +64,9 @@ TEST_F(AcceptanceTest, givenMemoryLeakWhenGettingAllocationThenReturnOneAllocati
 }
 
 TEST_F(AcceptanceTestWithSymbols, givenSymbolsPresentResolvingSymbolsThenReturnCorrectSymbols) {
+    initArgs.trackStackTraces = true;
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
+
     auto memory = allocateMemoryFunction(13);
 
     OakumAllocation *allocations{};
@@ -94,6 +101,9 @@ TEST_F(AcceptanceTestWithSymbols, givenSymbolsPresentResolvingSymbolsThenReturnC
 }
 
 TEST_F(AcceptanceTestWithSourceLocations, givenDebugConfigWhenResolvingSourceLocationsThenReturnLocations) {
+    initArgs.trackStackTraces = true;
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
+
     auto memory = allocateMemoryFunction(13);
 
     OakumAllocation *allocations{};
@@ -124,6 +134,11 @@ TEST_F(AcceptanceTestWithSourceLocations, givenDebugConfigWhenResolvingSourceLoc
 }
 
 TEST_F(AcceptanceTestWithoutSourceLocations, givenReleaseConfigWhenResolvingSourceLocationsThenReturnFallbackLocations) {
+    initArgs.trackStackTraces = true;
+    initArgs.fallbackSourceFileName = "fallbackFile";
+    initArgs.fallbackSymbolName = "fallbackSymbol";
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
+
     auto memory = allocateMemoryFunction(13);
 
     OakumAllocation *allocations{};
@@ -153,7 +168,9 @@ TEST_F(AcceptanceTestWithoutSourceLocations, givenReleaseConfigWhenResolvingSour
 }
 
 TEST_F(AcceptanceTest, givenThreadSafeOakumWhenMultiThreadedAllocationsAreDoneThenCorrectlyDetectLeaks) {
-    ASSERT_TRUE(initArgs.threadSafe);
+    initArgs.threadSafe = true;
+    initArgs.trackStackTraces = true;
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
 
     auto threadFunction = []() {
         constexpr size_t allocCount = 20;
@@ -181,7 +198,9 @@ TEST_F(AcceptanceTest, givenThreadSafeOakumWhenMultiThreadedAllocationsAreDoneTh
 }
 
 TEST_F(AcceptanceTest, givenThreadSafeOakumWhenMultiThreadedAllocationsAreDoneThenCorrectlyReturnLeaks) {
-    ASSERT_TRUE(initArgs.threadSafe);
+    initArgs.threadSafe = true;
+    initArgs.trackStackTraces = true;
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
 
     auto threadFunction = []() {
         constexpr size_t allocCount = 20;

--- a/tests/acceptance_tests/main.cpp
+++ b/tests/acceptance_tests/main.cpp
@@ -65,6 +65,8 @@ TEST_F(AcceptanceTest, givenMemoryLeakWhenGettingAllocationThenReturnOneAllocati
 
 TEST_F(AcceptanceTestWithSymbols, givenSymbolsPresentResolvingSymbolsThenReturnCorrectSymbols) {
     initArgs.trackStackTraces = true;
+    initArgs.fallbackSymbolName = "fallbackSymbol";
+    initArgs.fallbackSourceFileName = "fallbackFile";
     EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
 
     auto memory = allocateMemoryFunction(13);

--- a/tests/unit_tests/api/detect_leaks_tests.cpp
+++ b/tests/unit_tests/api/detect_leaks_tests.cpp
@@ -1,9 +1,6 @@
 #include "tests/common/allocate_memory_function.h"
 #include "tests/common/fixtures.h"
 
-#include <atomic>
-#include <thread>
-
 using OakumDetectLeaksTest = OakumTest;
 
 TEST_F(OakumDetectLeaksTest, givenLeaksWhenCallingOakumDetectLeaksThenReportLeaks) {
@@ -22,46 +19,4 @@ TEST_F(OakumDetectLeaksTest, givenLeaksWhenCallingOakumDetectLeaksThenReportLeak
 
     memory1.reset();
     EXPECT_OAKUM_SUCCESS(oakumDetectLeaks());
-}
-
-TEST_F(OakumDetectLeaksTest, givenLeaksInDifferentThreadWhenCallingOakumDetectLeaksThenReportLeaks) {
-    std::atomic_uint32_t sharedFlag = 0;
-    auto waitFlag = [&sharedFlag](uint32_t value) { while(sharedFlag != value){} };
-    auto notifyFlag = [&sharedFlag](uint32_t value) { sharedFlag = value; };
-
-    std::thread thread{[&waitFlag, &notifyFlag]() {
-        // Leak memory
-        waitFlag(1);
-        auto memory = allocateMemoryFunction();
-        notifyFlag(2);
-
-        // Free memory
-        waitFlag(3);
-        memory.reset();
-        notifyFlag(4);
-
-        // Finish
-        waitFlag(5);
-        notifyFlag(6);
-    }};
-
-    // Initialize Oakum
-    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
-    EXPECT_OAKUM_SUCCESS(oakumDetectLeaks());
-
-    // Notify thread, so it leaks memory
-    notifyFlag(1);
-    waitFlag(2);
-    EXPECT_EQ(OAKUM_LEAKS_DETECTED, oakumDetectLeaks());
-
-    // Notify thread, so it frees memory
-    notifyFlag(3);
-    waitFlag(4);
-    EXPECT_OAKUM_SUCCESS(oakumDetectLeaks());
-    notifyFlag(5);
-
-    // Notify thread, so it finishes
-    notifyFlag(5);
-    waitFlag(6);
-    thread.join();
 }

--- a/tests/unit_tests/api/detect_leaks_tests.cpp
+++ b/tests/unit_tests/api/detect_leaks_tests.cpp
@@ -1,15 +1,14 @@
 #include "tests/common/allocate_memory_function.h"
 #include "tests/common/fixtures.h"
 
+#include <atomic>
+#include <thread>
+
 using OakumDetectLeaksTest = OakumTest;
 
-TEST_F(OakumDetectLeaksTest, givenOakumNotInitializedWhenCallingOakumDetectLeaksThenFail) {
-    EXPECT_OAKUM_SUCCESS(oakumDeinit(false));
-    EXPECT_EQ(OAKUM_UNINITIALIZED, oakumReleaseAllocations(nullptr, 0u));
-    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
-}
-
 TEST_F(OakumDetectLeaksTest, givenLeaksWhenCallingOakumDetectLeaksThenReportLeaks) {
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
+
     EXPECT_OAKUM_SUCCESS(oakumDetectLeaks());
 
     auto memory0 = allocateMemoryFunction();
@@ -23,4 +22,46 @@ TEST_F(OakumDetectLeaksTest, givenLeaksWhenCallingOakumDetectLeaksThenReportLeak
 
     memory1.reset();
     EXPECT_OAKUM_SUCCESS(oakumDetectLeaks());
+}
+
+TEST_F(OakumDetectLeaksTest, givenLeaksInDifferentThreadWhenCallingOakumDetectLeaksThenReportLeaks) {
+    std::atomic_uint32_t sharedFlag = 0;
+    auto waitFlag = [&sharedFlag](uint32_t value) { while(sharedFlag != value){} };
+    auto notifyFlag = [&sharedFlag](uint32_t value) { sharedFlag = value; };
+
+    std::thread thread{[&waitFlag, &notifyFlag]() {
+        // Leak memory
+        waitFlag(1);
+        auto memory = allocateMemoryFunction();
+        notifyFlag(2);
+
+        // Free memory
+        waitFlag(3);
+        memory.reset();
+        notifyFlag(4);
+
+        // Finish
+        waitFlag(5);
+        notifyFlag(6);
+    }};
+
+    // Initialize Oakum
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
+    EXPECT_OAKUM_SUCCESS(oakumDetectLeaks());
+
+    // Notify thread, so it leaks memory
+    notifyFlag(1);
+    waitFlag(2);
+    EXPECT_EQ(OAKUM_LEAKS_DETECTED, oakumDetectLeaks());
+
+    // Notify thread, so it frees memory
+    notifyFlag(3);
+    waitFlag(4);
+    EXPECT_OAKUM_SUCCESS(oakumDetectLeaks());
+    notifyFlag(5);
+
+    // Notify thread, so it finishes
+    notifyFlag(5);
+    waitFlag(6);
+    thread.join();
 }

--- a/tests/unit_tests/api/get_allocations_tests.cpp
+++ b/tests/unit_tests/api/get_allocations_tests.cpp
@@ -1,6 +1,6 @@
 #include "tests/common/fixtures.h"
 
-struct OakumGetAllocationsTest : OakumTestWithAllocationSorting {
+struct OakumGetAllocationsTest : OakumTest {
     void validateStackFrames(OakumAllocation &allocation) {
         EXPECT_GE(allocation.stackFramesCount, 0u);
 
@@ -29,12 +29,17 @@ TEST_F(OakumGetAllocationsTest, givenOakumNotInitializedWhenCallingOakumGetAlloc
     OakumAllocation *allocations = nullptr;
     size_t allocationCount = 0u;
 
-    EXPECT_OAKUM_SUCCESS(oakumDeinit(false));
     EXPECT_EQ(OAKUM_UNINITIALIZED, oakumGetAllocations(&allocations, &allocationCount));
+
     EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
+    EXPECT_OAKUM_SUCCESS(oakumDeinit(false));
+
+    EXPECT_EQ(OAKUM_UNINITIALIZED, oakumGetAllocations(&allocations, &allocationCount));
 }
 
 TEST_F(OakumGetAllocationsTest, givenNoAllocationsWhenCallingOakumGetAllocationsThenReturnNoAllocations) {
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
+
     OakumAllocation *allocations = nullptr;
     size_t allocationCount = 0u;
 
@@ -45,6 +50,8 @@ TEST_F(OakumGetAllocationsTest, givenNoAllocationsWhenCallingOakumGetAllocations
 }
 
 TEST_F(OakumGetAllocationsTest, givenIllegalNullArgumentsWhenCallingOakumGetAllocationsThenReturnInvalidValue) {
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
+
     OakumAllocation *allocations = nullptr;
     size_t allocationCount = 0u;
 
@@ -53,7 +60,10 @@ TEST_F(OakumGetAllocationsTest, givenIllegalNullArgumentsWhenCallingOakumGetAllo
     EXPECT_EQ(OAKUM_INVALID_VALUE, oakumGetAllocations(nullptr, nullptr));
 }
 
-TEST_F(OakumGetAllocationsTest, givenSomeAllocationsWhenCallingOakumGetAllocationsThenReturnThem) {
+TEST_F(OakumGetAllocationsTest, givenSortAllocationsWhenCallingOakumGetAllocationsThenReturnSortedAllocations) {
+    initArgs.sortAllocations = true;
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
+
     char *a = new char;
     int *b = new int;
     int *c = new int[12];
@@ -89,7 +99,10 @@ TEST_F(OakumGetAllocationsTest, givenSomeAllocationsWhenCallingOakumGetAllocatio
     EXPECT_OAKUM_SUCCESS(oakumReleaseAllocations(allocations, allocationCount));
 }
 
-TEST_F(OakumGetAllocationsTest, givenSomeNoThrowAllocationsWhenCallingOakumGetAllocationsThenReturnThem) {
+TEST_F(OakumGetAllocationsTest, givenSortAllocationsAndNoThrowNewWhenCallingOakumGetAllocationsThenReturnSortedAllocations) {
+    initArgs.sortAllocations = true;
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
+
     char *a = new (std::nothrow) char;
     int *b = new (std::nothrow) int;
     int *c = new (std::nothrow) int[12];
@@ -125,9 +138,9 @@ TEST_F(OakumGetAllocationsTest, givenSomeNoThrowAllocationsWhenCallingOakumGetAl
     EXPECT_OAKUM_SUCCESS(oakumReleaseAllocations(allocations, allocationCount));
 }
 
-using OakumGetAllocationsWithoutStackTracesTest = OakumTestWithoutStackTraces;
+TEST_F(OakumGetAllocationsTest, givenNoStackTracesWhenCallingOakumGetAllocationsThenReturnThemWithoutStackTraces) {
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
 
-TEST_F(OakumGetAllocationsWithoutStackTracesTest, givenNoStackTracesWhenCallingOakumGetAllocationsThenReturnThemWithoutStackTraces) {
     char *memory = new char;
 
     OakumAllocation *allocations = nullptr;
@@ -145,4 +158,35 @@ TEST_F(OakumGetAllocationsWithoutStackTracesTest, givenNoStackTracesWhenCallingO
     delete memory;
 
     EXPECT_OAKUM_SUCCESS(oakumReleaseAllocations(allocations, allocationCount));
+}
+
+TEST_F(OakumGetAllocationsTest, givenStackTracesWhenCallingOakumGetAllocationsThenReturnThemWithStackTraces) {
+    initArgs.trackStackTraces = true;
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
+
+    char *memory = new char;
+
+    OakumAllocation *allocations = nullptr;
+    size_t allocationCount = 0u;
+    EXPECT_OAKUM_SUCCESS(oakumGetAllocations(&allocations, &allocationCount));
+    EXPECT_NE(nullptr, allocations);
+    EXPECT_EQ(1u, allocationCount);
+
+    EXPECT_EQ(1u, allocations[0].allocationId);
+    EXPECT_EQ(sizeof(char), allocations[0].size);
+    EXPECT_EQ(memory, allocations[0].pointer);
+    EXPECT_FALSE(allocations[0].noThrow);
+    EXPECT_LT(0u, allocations[0].stackFramesCount);
+    for (size_t i = 0u; i < allocations[0].stackFramesCount; i++) {
+        EXPECT_NE(nullptr, allocations[0].stackFrames[i].address);
+    }
+
+    delete memory;
+
+    EXPECT_OAKUM_SUCCESS(oakumReleaseAllocations(allocations, allocationCount));
+}
+
+TEST_F(OakumGetAllocationsTest, givenOakumNotInitializedWhenCallingOakumDetectLeaksThenFail) {
+    EXPECT_EQ(OAKUM_UNINITIALIZED, oakumReleaseAllocations(nullptr, 0u));
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
 }

--- a/tests/unit_tests/api/ignore_tests.cpp
+++ b/tests/unit_tests/api/ignore_tests.cpp
@@ -6,13 +6,13 @@ using OakumIgnoreTest = OakumTest;
 TEST_F(OakumIgnoreTest, givenOakumNotInitializedWhenCallingOakumIgnoreFunctionsThenFail) {
     size_t returned{};
     size_t available{};
-    EXPECT_OAKUM_SUCCESS(oakumDeinit(false));
     EXPECT_EQ(OAKUM_UNINITIALIZED, oakumStartIgnore());
     EXPECT_EQ(OAKUM_UNINITIALIZED, oakumStopIgnore());
-    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
 }
 
 TEST_F(OakumIgnoreTest, givenOakumIgnoreIsStartedWhenMemoryIsAllocatedThenItIsNotRecorded) {
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
+
     OakumAllocation *allocations = nullptr;
     size_t allocationCount = 0u;
     EXPECT_OAKUM_SUCCESS(oakumStartIgnore());
@@ -33,6 +33,8 @@ TEST_F(OakumIgnoreTest, givenOakumIgnoreIsStartedWhenMemoryIsAllocatedThenItIsNo
 }
 
 TEST_F(OakumIgnoreTest, givenOakumIgnoreIsCalledMultipleTimesWhenMemoryIsAllocatedThenItIgnoreStateIsRefcounted) {
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
+
     OakumAllocation *allocations = nullptr;
     size_t allocationCount = 0u;
     EXPECT_OAKUM_SUCCESS(oakumStartIgnore());
@@ -64,6 +66,8 @@ TEST_F(OakumIgnoreTest, givenOakumIgnoreIsCalledMultipleTimesWhenMemoryIsAllocat
 }
 
 TEST_F(OakumIgnoreTest, givenOakumStopIgnoreIsCalledWhenIgnoreCountIsZeroThenReturnError) {
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
+
     EXPECT_EQ(OAKUM_NOT_IGNORING, oakumStopIgnore());
 
     EXPECT_OAKUM_SUCCESS(oakumStartIgnore());

--- a/tests/unit_tests/api/init_tests.cpp
+++ b/tests/unit_tests/api/init_tests.cpp
@@ -2,6 +2,7 @@
 #include "tests/common/fixtures.h"
 
 TEST(OakumInitTest, givenOakumInitAndDeinitCalledWhenEnvironmentIsCleanThenSuccessIsReturned) {
+    OakumInitArgs defaultInitArgs{};
     EXPECT_OAKUM_SUCCESS(oakumInit(&defaultInitArgs));
     EXPECT_OAKUM_SUCCESS(oakumDeinit(false));
 
@@ -10,6 +11,7 @@ TEST(OakumInitTest, givenOakumInitAndDeinitCalledWhenEnvironmentIsCleanThenSucce
 }
 
 TEST(OakumInitTest, givenOakumInitCalledMultipleTimesWhenEnvironmentIsCleanThenOnlyTheFirstOneSucceeds) {
+    OakumInitArgs defaultInitArgs{};
     EXPECT_OAKUM_SUCCESS(oakumInit(&defaultInitArgs));
     EXPECT_EQ(OAKUM_ALREADY_INITIALIZED, oakumInit(nullptr));
     EXPECT_EQ(OAKUM_ALREADY_INITIALIZED, oakumInit(nullptr));
@@ -21,6 +23,7 @@ TEST(OakumInitTest, givenOakumDeinitCalledWhenOakumIsNotInitializedThenFail) {
 }
 
 TEST(OakumInitTest, givenLeaksDetectionEnabledWhenOakumDeinitIsCalledThenDetectLeaks) {
+    OakumInitArgs defaultInitArgs{};
     EXPECT_OAKUM_SUCCESS(oakumInit(&defaultInitArgs));
     EXPECT_OAKUM_SUCCESS(oakumDeinit(true));
 

--- a/tests/unit_tests/api/operator_tests.cpp
+++ b/tests/unit_tests/api/operator_tests.cpp
@@ -7,7 +7,10 @@ struct OakumOperatorTest : OakumTest {
     }
 };
 
+// TODO test all possible operators
+
 TEST_F(OakumOperatorTest, givenNoThrowNotSpecifiedWhenMemoryAllocationFailsThenThrowBadAlloc) {
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
     EXPECT_THROW(allocateMemoryFunction(getHugeMemorySize()), std::bad_alloc);
     EXPECT_EQ(nullptr, allocateMemoryFunctionNoThrow(getHugeMemorySize()));
 }

--- a/tests/unit_tests/api/release_allocations_tests.cpp
+++ b/tests/unit_tests/api/release_allocations_tests.cpp
@@ -4,12 +4,12 @@
 using OakumReleaseAllocationsTest = OakumTest;
 
 TEST_F(OakumReleaseAllocationsTest, givenOakumNotInitializedWhenCallingOakumReleaseAllocationsThenFail) {
-    EXPECT_OAKUM_SUCCESS(oakumDeinit(false));
     EXPECT_EQ(OAKUM_UNINITIALIZED, oakumReleaseAllocations(nullptr, 0u));
-    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
 }
 
 TEST_F(OakumReleaseAllocationsTest, givenNullArgumentsWhenCallingOakumReleaseAllocationsThenReturnCorrectValues) {
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
+
     OakumAllocation *allocations = reinterpret_cast<OakumAllocation *>(0x1234);
     size_t allocationCount = 1u;
 
@@ -19,6 +19,8 @@ TEST_F(OakumReleaseAllocationsTest, givenNullArgumentsWhenCallingOakumReleaseAll
 }
 
 TEST_F(OakumReleaseAllocationsTest, givenAllocationWhenCallingOakumReleaseAllocationsThenItFixesMemoryLeak) {
+    EXPECT_OAKUM_SUCCESS(oakumInit(&initArgs));
+
     auto memory = allocateMemoryFunction();
 
     OakumAllocation *allocations = nullptr;


### PR DESCRIPTION
This reduces the number of subclasses that need to be derived from OakumTest just to sligthly alter initArgs